### PR TITLE
Added `version` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.20
 require (
 	github.com/arduino/go-paths-helper v1.9.1
 	github.com/spf13/cobra v1.7.0
-	go.bug.st/relaxed-semver v0.10.2
+	go.bug.st/relaxed-semver v0.11.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,9 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-go.bug.st/relaxed-semver v0.10.2 h1:d/ATAG3MByySZgg7rFj+Wj0fhvP4zfx9Z8Dn/NSCoFg=
-go.bug.st/relaxed-semver v0.10.2/go.mod h1:lPVGdtzbQ9/2fv6iXqIXWHOj6cMTUJ/l/Lu1w+sgdio=
+go.bug.st/relaxed-semver v0.11.0 h1:ngzpUlBEZ5F9hJnMZP55LIFbgX3bCztBBufMhJViAsY=
+go.bug.st/relaxed-semver v0.11.0/go.mod h1:rqPEm+790OTQlAdfSJSHWwpKOg3A8UyvAWMZxYkQivc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
It returns information about the plugin, but more importantly, it returns information on the plugin_api version:

```
$ go build
$ ./dummy-plugin
dummy - This is an Arduino Firmware Uploader plugin.

Usage:
  dummy-plugin [command]

Available Commands:
  cert        Certificates handling commands
  completion  Generate the autocompletion script for the specified shell
  firmware    Firmware handling commands
  help        Help about any command
  version     Return informations about this fw-updater plugin

Flags:
  -p, --address string   Port address
  -h, --help             help for dummy-plugin

Use "dummy-plugin [command] --help" for more information about a command.
$ ./dummy-plugin version
plugin_info:
    name: dummy
    version: 1.0.0
plugin_api_version: 1
```

If in the future we will add more functionality we could increase the `plugin_api_version` to maintain backward compatibility.
