### PR TITLE
Fix tools path calculation

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -30,7 +30,7 @@ func FindToolPath(toolName string, toolVersion *semver.Version) (*paths.Path, er
 	if err != nil {
 		return nil, err
 	}
-	toolsDir := paths.New(executablePath).Parent()
+	toolsDir := paths.New(executablePath).Parent().Parent().Parent()
 	toolPath := toolsDir.Join(toolName, toolVersion.String())
 	if !toolPath.IsDir() {
 		return nil, fmt.Errorf("tool not found: %s@%s", toolName, toolVersion)


### PR DESCRIPTION
Following the dir structure of the fwuploader downloads:

```
/tmp/fwuploader$ tree
.
├── module_firmware_index.json
├── module_firmware_index.json.sig
├── package_index.json
├── package_index.json.sig
└── tools
    ├── bossac
    │   └── 1.9.1-arduino5
    │       └── bossac
    ├── espflash
    │   └── 2.0.0
    │       ├── espflash
    │       └── LICENSE.txt
    └── uno-r4-wifi-fwuploader-plugin
        └── 0.0.1
            └── uno-r4-wifi-fwuploader-plugin
```

there are two missing `Parent()` calls... 🤦🏼 
