### PR TITLE
add `fqbn` flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -31,6 +31,7 @@ func RunPlugin(plugin Plugin) {
 	info := plugin.GetPluginInfo()
 
 	var portAddress string
+	var fqbn string
 
 	firmwareFlashCmd := &cobra.Command{
 		Use:   "flash",
@@ -42,6 +43,7 @@ func RunPlugin(plugin Plugin) {
 			fwPath := paths.New(args[0])
 			err := plugin.UploadFirmware(
 				portAddress,
+				fqbn,
 				fwPath,
 				&PluginFeedback{stdOut: os.Stdout, stdErr: os.Stderr},
 			)
@@ -60,6 +62,7 @@ func RunPlugin(plugin Plugin) {
 			}
 			version, err := plugin.GetFirmwareVersion(
 				portAddress,
+				fqbn,
 				&PluginFeedback{stdOut: os.Stdout, stdErr: os.Stderr},
 			)
 			if err != nil {
@@ -86,6 +89,7 @@ func RunPlugin(plugin Plugin) {
 			certPath := paths.New(args[0])
 			err := plugin.UploadCertificate(
 				portAddress,
+				fqbn,
 				certPath,
 				&PluginFeedback{stdOut: os.Stdout, stdErr: os.Stderr},
 			)
@@ -118,6 +122,9 @@ func RunPlugin(plugin Plugin) {
 	cli.AddCommand(certCmd)
 	cli.AddCommand(versionCmd)
 	cli.PersistentFlags().StringVarP(&portAddress, "address", "p", "", "Port address")
+	// The fqbn is an optional flag that can be used by the plugin to do specific operations with a board.
+	// With this input we can support a family of boards and not only a single one per plugin
+	cli.PersistentFlags().StringVarP(&fqbn, "fqbn", "b", "", "Fully qualified board name")
 
 	if err := cli.Execute(); err != nil {
 		fatal(err.Error(), 1)

--- a/dummy-plugin/main.go
+++ b/dummy-plugin/main.go
@@ -41,12 +41,29 @@ func (d *dummyPlugin) GetPluginInfo() *helper.PluginInfo {
 }
 
 // UploadFirmware performs a firmware upload on the board
-func (d *dummyPlugin) UploadFirmware(portAddress string, firmwarePath *paths.Path, feedback *helper.PluginFeedback) error {
+func (d *dummyPlugin) UploadFirmware(portAddress, fqbn string, firmwarePath *paths.Path, feedback *helper.PluginFeedback) error {
 	if portAddress == "" {
 		fmt.Fprintln(feedback.Err(), "Port address not specified")
 		return fmt.Errorf("invalid port address")
 	}
 	fmt.Fprintf(feedback.Out(), "Uploading %s to %s...\n", firmwarePath, portAddress)
+	if fqbn == "" {
+		fmt.Fprintln(feedback.Err(), "FQBN not specified")
+		return fmt.Errorf("invalid fqbn")
+	}
+
+	// Providing the fqbn to the plugin allows us to support a family of boards instead of a single one
+	switch fqbn {
+	case "arduino:renesas_uno:unor5":
+		// Do some board specific operations here
+		fmt.Fprintf(feedback.Out(), "Uploading firmware for %s \n", fqbn)
+	case "arduino:renesas_uno:unor4wifi":
+		// Do some board specific operations here
+		fmt.Fprintf(feedback.Out(), "Uploading firmware for %s \n", fqbn)
+	default:
+		fmt.Fprintf(feedback.Err(), "FQBN %s not supported by the plugin\n", fqbn)
+		return fmt.Errorf("invalid fqbn")
+	}
 
 	// Fake upload
 	time.Sleep(5 * time.Second)
@@ -56,7 +73,7 @@ func (d *dummyPlugin) UploadFirmware(portAddress string, firmwarePath *paths.Pat
 }
 
 // UploadCertificate performs a certificate upload on the board
-func (d *dummyPlugin) UploadCertificate(portAddress string, certificatePath *paths.Path, feedback *helper.PluginFeedback) error {
+func (d *dummyPlugin) UploadCertificate(portAddress, fqbn string, certificatePath *paths.Path, feedback *helper.PluginFeedback) error {
 	if portAddress == "" {
 		fmt.Fprintln(feedback.Err(), "Port address not specified")
 		return fmt.Errorf("invalid port address")
@@ -71,7 +88,7 @@ func (d *dummyPlugin) UploadCertificate(portAddress string, certificatePath *pat
 }
 
 // GetFirmwareVersion retrieve the firmware version installed on the board
-func (d *dummyPlugin) GetFirmwareVersion(portAddress string, feedback *helper.PluginFeedback) (*semver.RelaxedVersion, error) {
+func (d *dummyPlugin) GetFirmwareVersion(portAddress, fqbn string, feedback *helper.PluginFeedback) (*semver.RelaxedVersion, error) {
 	if portAddress == "" {
 		fmt.Fprintln(feedback.Err(), "Port address not specified")
 		return nil, fmt.Errorf("invalid port address")

--- a/plugin.go
+++ b/plugin.go
@@ -30,13 +30,13 @@ type Plugin interface {
 	GetPluginInfo() *PluginInfo
 
 	// UploadFirmware performs a firmware upload on the board
-	UploadFirmware(portAddress string, firmwarePath *paths.Path, feedback *PluginFeedback) error
+	UploadFirmware(portAddress, fqbn string, firmwarePath *paths.Path, feedback *PluginFeedback) error
 
 	// UploadCertificate performs a certificate upload on the board
-	UploadCertificate(portAddress string, certificatePath *paths.Path, feedback *PluginFeedback) error
+	UploadCertificate(portAddress, fqbn string, certificatePath *paths.Path, feedback *PluginFeedback) error
 
 	// GetFirmwareVersion retrieve the firmware version installed on the board
-	GetFirmwareVersion(portAddress string, feedback *PluginFeedback) (*semver.RelaxedVersion, error)
+	GetFirmwareVersion(portAddress, fqbn string, feedback *PluginFeedback) (*semver.RelaxedVersion, error)
 }
 
 // PluginInfo is a set of information describing the plugin


### PR DESCRIPTION
This change in the interface allows more flexibility in the plugin:
We can now develop a plugin for a family of boards (NINA boards for example). Previously we the only possibility could have been a plugin for every board.
The flag is completely optional, and it is the responsibility of the plugin to use it or to ignore it.