### PR TITLE
Add GitHub Actions workflow to generate releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,74 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-tag.md
+name: Release
+
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    env:
+      # See: https://github.com/fsaintjacques/semver-tool/releases
+      SEMVER_TOOL_VERSION: 3.2.0
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
+          echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Create changelog
+        uses: arduino/create-changelog@v1
+        with:
+          tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
+          filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
+          case-insensitive-regex: true
+          changelog-file-path: ${{ env.CHANGELOG_PATH }}
+
+      - name: Download semver tool
+        id: download-semver-tool
+        uses: carlosperate/download-file-action@v2
+        with:
+          file-url: https://github.com/fsaintjacques/semver-tool/archive/${{ env.SEMVER_TOOL_VERSION }}.zip
+          location: ${{ runner.temp }}/semver-tool
+
+      - name: Install semver tool
+        run: |
+          unzip \
+            -p \
+            "${{ steps.download-semver-tool.outputs.file-path }}" \
+            semver-tool-${{ env.SEMVER_TOOL_VERSION }}/src/semver > \
+              "${{ env.SEMVER_TOOL_PATH }}"
+          chmod +x "${{ env.SEMVER_TOOL_PATH }}"
+
+      - name: Identify Prerelease
+        id: prerelease
+        run: |
+          if [[ \
+            "$(
+              "${{ env.SEMVER_TOOL_PATH }}" get prerel \
+                "${GITHUB_REF/refs\/tags\//}"
+            )" != \
+            "" \
+          ]]; then
+            echo "IS_PRE=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bodyFile: ${{ env.CHANGELOG_PATH }}
+          draft: false
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Check Go Dependencies status](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/check-go-dependencies-task.yml/badge.svg)](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/check-go-dependencies-task.yml)
 [![Check Taskfiles status](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/check-taskfiles.yml)
 [![Check Workflows status](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/check-workflows-task.yml)
+[![Release status](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/release-tag.yml/badge.svg)](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/release-tag.yml)
 
 <!--[![Test Go status](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/arduino/fwuploader-plugin-helper/actions/workflows/test-go-task.yml)-->
 <!--[![Codecov](https://codecov.io/gh/arduino/fwuploader-plugin-helper/branch/main/graph/badge.svg)](https://codecov.io/gh/arduino/fwuploader-plugin-helper)-->


### PR DESCRIPTION
On every push of a release tag (e.g., `1.2.3` or `v1.2.3`) to the repository, create a [GitHub release](https://docs.github.com/repositories/releasing-projects-on-github/about-releases) with a raw [changelog generated](https://github.com/arduino/create-changelog) from the commit history since the last release tag.

Tags that contain a [pre-release version](https://semver.org/#spec-item-9) will cause the GitHub release to be marked as a pre-release.